### PR TITLE
[koa-playground] Make memory db wrapper with buntDB for deploy and execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 koa-playground provides an environment where you can easily test and run the language of your [koa project](https://github.com/DE-labtory/koa).
 
+### The difference between koa-playground and other editors
+
+koa used in koa-playground is different from the general programming languages. Similarly, koa program also has difference from the general programs. First, koa has `deploy` step. This step deliveries an information of the contract to the `vm`. And, user needs to `call` the function in order to run the program.
+
+Thus, you should use koa-playground which supports the above, if you want to make and execute the koa program!
+
+### Koa-Playground Architecture
+
+<p align="center"><img src="./image/playground-architecture.jpg" weight="510" height="240px"></p>
+
+`Front End` has two components. `Editor` is the code editor using koa. `Console` shows the result of running the program.
+
+`Back End` also has two components. `Compiler` receives the source code from `Editor`. Then, compiles code and returns `Bytecode`. If `Console` deploys the bytecode, `Virtual Machine` saves it and returns the address of the contract deployed. When the user calls the function, call data is delivered to `Virtual Machine`. `Virtual Machine` executes it and returns the ouput of that function call.
+
 ### Back End
 
 koa-playground uses `HTTP protocol`. It has 3 communications. Also, all data is encoded in UTF-8.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ type CompileRequest struct {
 type CompileResponse struct {
     ABI             abi
     RawByteCode     []byte
-    Asm             []string
+    ASM             []string
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,6 @@
 
 koa-playground provides an environment where you can easily test and run the language of your [koa project](https://github.com/DE-labtory/koa).
 
-### The difference between koa-playground and other editors
-
-koa used in koa-playground is different from the general programming languages. Similarly, koa program also has difference from the general programs. First, koa has `deploy` step. This step deliveries an information of the contract to the `vm`. And, user needs to `call` the function in order to run the program.
-
-Thus, you should use koa-playground which supports the above, if you want to make and execute the koa program!
-
-### Koa-Playground Architecture
-
-<p align="center"><img src="./image/playground-architecture.jpg" weight="510" height="240px"></p>
-
-`Front End` has two components. `Editor` is the code editor using koa. `Console` shows the result of running the program.
-
-`Back End` also has two components. `Compiler` receives the source code from `Editor`. Then, compiles code and returns `Bytecode`. If `Console` deploys the bytecode, `Virtual Machine` saves it and returns the address of the contract deployed. When the user calls the function, call data is delivered to `Virtual Machine`. `Virtual Machine` executes it and returns the ouput of that function call.
-
 ### Back End
 
 koa-playground uses `HTTP protocol`. It has 3 communications. Also, all data is encoded in UTF-8.

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -39,5 +39,5 @@ func main() {
 
 
 	// Start server
-	e.Logger.Fatal(e.Start(":1323"))
+	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/backend/handlers/memcache.go
+++ b/backend/handlers/memcache.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"github.com/tidwall/buntdb"
+	"time"
+)
+
+var defaultExpireHours = 4
+
+func Save(key, value string, db *buntdb.DB) error {
+	return SaveWithTTL(key, value, db, 1)
+}
+
+func SaveWithTTL(key, value string, db *buntdb.DB, hours int) error {
+	if hours <= 0 {
+		hours = defaultExpireHours
+	}
+	return db.Update(func(tx *buntdb.Tx) error {
+		tx.Set(key, value, &buntdb.SetOptions{Expires: true, TTL: time.Second * time.Duration(hours)})
+		return nil
+	})
+}
+
+func Delete(keys []string, db *buntdb.DB) error {
+	return db.Update(func(tx *buntdb.Tx) error {
+		for _, key := range keys {
+			if _, err := tx.Delete(key); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func Update(key, newValue string, db *buntdb.DB) error {
+	return UpdateWithTTL(key, newValue, db, 1)
+}
+
+func UpdateWithTTL(key, newValue string, db *buntdb.DB, hours int) error {
+	if hours <= 0 {
+		hours = defaultExpireHours
+	}
+	return db.Update(func(tx *buntdb.Tx) error {
+		tx.Set(key, newValue, &buntdb.SetOptions{Expires: true, TTL: time.Second * time.Duration(hours)})
+		return nil
+	})
+}


### PR DESCRIPTION
Fixes #23

## Proposed Changes

 - Made light wrapper memory-db using buntDB
 - Change default port because GCP(google cloud platform) is not support known port
